### PR TITLE
Resolve entry file locally

### DIFF
--- a/bin/main.js
+++ b/bin/main.js
@@ -39,7 +39,7 @@ function transformModule(name, fileFilter) {
 }
 
 
-var rmod = resolve.sync(argv._[0], {basedir: process.cwd()});
+var rmod = resolve.sync('./' + argv._[0], {basedir: process.cwd()});
 
 loadModule.tracingEnabled = true;
 process.argv = argv._;


### PR DESCRIPTION
Filenames require explicit dot-slash to be resolved properly.

```
$ node test/test.js
# ... failures ...

$ node-trace test/test.js
Error: Cannot find module 'test/test.js' from ...

$ node-trace ./test/test.js
# ... trace ...
```

This is confusing and not expected. I can't think of any use case where I would want to trace some other module. If such use cases exist, it might be better to hide this feature under a flag and treat filename locally by default.
