### PR TITLE
Print filenames relative to working dir

### DIFF
--- a/default-tracer.js
+++ b/default-tracer.js
@@ -1,5 +1,7 @@
+var path = require('path');
+
 exports.trace = function(filename, line, col) {
-    console.log(filename, line + ':' + col);
+    console.log(path.relative(process.cwd(), filename), line + ':' + col);
 }
 
 exports.filter = function(filename) {


### PR DESCRIPTION
This patch makes default tracer print filenames relative to the current working directory. In many cases full paths are long and have fixed prefix which makes it a bit harder to process through.

Instead of

```
/home/user/path/to/project/directory/index.js 1:2
/home/user/path/to/project/directory/lib/module1.js 2:3
/home/user/path/to/project/directory/lib/module2.js 3:4
/home/user/path/to/project/directory/index.js 2:3
/home/user/path/to/project/directory/lib/module1.js 2:3
```

with this patch the trace will look like

```
index.js 1:2
lib/module1.js 2:3
lib/module2.js 3:4
index.js 2:3
lib/module1.js 2:3
```

which opens the door for some useful details and makes output more concise. The default tracer shouldn't look cluttered.
