### PR TITLE
Unshift interpreter argument to process.argv

### DIFF
--- a/bin/main.js
+++ b/bin/main.js
@@ -42,5 +42,5 @@ function transformModule(name, fileFilter) {
 var rmod = resolve.sync('./' + argv._[0], {basedir: process.cwd()});
 
 loadModule.tracingEnabled = true;
-process.argv = argv._;
+process.argv = [process.argv[0]].concat(argv._);
 require(rmod);


### PR DESCRIPTION
This patch fixes `process.argv` for the traced module.

Original `process.argv` might be:

``` json
["/path/to/node", "/path/to/node-tracer", "./index.js", "arg0", "arg1"]
```

Current version from master changes `process.argv` to be:

``` json
["./index.js", "arg0", "arg1"]
```

This patch adds missing first argument:

``` json
["/path/to/node", "./index.js", "arg0", "arg1"]
```

This allows tracing CLI modules that otherwise would fail because arguments would start from `process.argv[1]` and not from `process.argv[2]` as they normally do.
