### PR TITLE
Upgrade to falafel@1.1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,12 @@
 var falafel = require('falafel');
 
 function instrumentSource(src) {
-    var out = falafel(src, {loc: true}, function(node) {
+    var opts = {
+        ecmaVersion: 6,
+        allowHashBang: true,
+        locations: true
+    };
+    var out = falafel(src, opts, function(node) {
         if ((node.type === 'FunctionDeclaration') ||
             (node.type === 'FunctionExpression')) {
             instrumentFunctionBody(node.body, node.id);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "spion",
   "license": "MIT",
   "dependencies": {
-    "falafel": "^0.3.1",
+    "falafel": "^1.1.0",
     "resolve": "^0.6.1",
     "optimist": "^0.6.1"
   }


### PR DESCRIPTION
This patch upgrades falafel to version 1.1.0 that comes with acorn parser (instead of esprima in pre-1.x versions).

acorn parser has option to ignore she-bangs like Node does (I have not found a way to do this with esprima) and has other nice features including better ES6 support.

Ignoring she-bangs is crucial for instrumenting CLI modules.
